### PR TITLE
Add ImplicitNoBuilder

### DIFF
--- a/src/Data/String/Syntax.hs
+++ b/src/Data/String/Syntax.hs
@@ -109,6 +109,15 @@ allModes =
       , processExpr = \expr -> "XX.fromString (XX.interpolate (" <> expr <> "))"
       }
   , InterpolationMode
+      { name = "implicit-no-builder"
+      , autoModules = ["Data.String.Syntax.ImplicitNoBuilder"]
+      , autoLangExts = []
+      , delimMarker = OnlyDelim "s"
+      , postProcess = \_ exprs -> "mconcat " <> exprs
+      , processRaw = showT
+      , processExpr = \expr -> "(XX.interpolate (" <> expr <> "))"
+      }
+  , InterpolationMode
       { name = "extensible-th"
       , autoModules = ["Data.String.Syntax.ExtensibleTH"]
       , autoLangExts = ["TemplateHaskell"]

--- a/src/Data/String/Syntax/ImplicitNoBuilder.hs
+++ b/src/Data/String/Syntax/ImplicitNoBuilder.hs
@@ -1,0 +1,17 @@
+module Data.String.Syntax.ImplicitNoBuilder where
+
+class Interpolate a s where
+  interpolate :: a -> s
+
+instance Interpolate a a where
+  interpolate = id
+instance Interpolate Char String where
+  interpolate = interpolate . (:[])
+instance Interpolate Bool String where
+  interpolate = show
+instance Interpolate Int String where
+  interpolate = show
+instance Interpolate Integer String where
+  interpolate = show
+instance Interpolate Double String where
+  interpolate = show

--- a/string-syntax.cabal
+++ b/string-syntax.cabal
@@ -29,6 +29,7 @@ library
       Data.String.Syntax.ExtensibleHasClass
       Data.String.Syntax.ExtensibleTH
       Data.String.Syntax.ImplicitBuilder
+      Data.String.Syntax.ImplicitNoBuilder
       Data.String.Syntax.ImplicitOnlyString
       Data.String.Syntax.Internal.Parse
   other-modules:


### PR DESCRIPTION
New mode which similar to implicit-builder but without builder i.e. desugars `s"a ${x} b"` to

    mconcat $
     [ fromString "a "
     , interpolate x
     , fromString "b"
    ]

I believe that it has the same power as the builder version, a builder class can be used directly by making it an instance of `IsString`.
However, it removes the type ambiguity created by `fromBuilder $ mconcat [toBuilder ...]` : builder can be anything.
With implicit-no-builder, there is no ambiguity. All the types (after the `mconcat` and inside the list are the same).

It also allows to use the polymorphic string. Example (SqlB is a poor man version of your SqlQuery example).


```
instance XX.Interpolate String Text where interpolate = pack
instance XX.Interpolate Double Text where interpolate = pack . XX.interpolate
instance XX.Interpolate Int Text where interpolate = pack . XX.interpolate


newtype SqlB = SqlB  [Either Text Text] deriving Show

instance XX.Interpolate Int SqlB where interpolate i = SqlB [Right $ tshow i ]
instance IsString SqlB where fromString s = SqlB [Left $ pack s]
instance Semigroup SqlB where SqlB a  <> SqlB b = SqlB (a <> b)
instance Monoid SqlB where mempty = SqlB []

toSql :: SqlB -> (Text, [Text])
toSql (SqlB xs) = (mconcat (map toquery xs), rights xs) where
   toquery e = case e of 
                Left x -> x
                Right _ -> "?"
toto :: Int
toto = 4
x = s"a = ${toto}"
```
As we can see` x` is polymorphicd
```
> :t x
x :: (Monoid a, IsString a, XX.Interpolate Int a) => a
```
it can be a `Text`
```
> x :: Text
"a = 4"
```
Or an `SqlB`
```
> x :: SqlB
SqlB [Left "a = ",Right "4"]
```
and converted to a sql query with parameter 
```
> toSql x
("a = ?",["4"])
```



    