### PR TITLE
New wired-in proposal version

### DIFF
--- a/examples/string-syntax-example.cabal
+++ b/examples/string-syntax-example.cabal
@@ -87,3 +87,17 @@ executable implicit-no-builder
     , string-syntax
     , text
   default-language: GHC2021
+
+executable uniform-interpolate-builder
+  hs-source-dirs: uniform-interpolate-builder, shared
+  main-is: main.hs
+  other-modules: StringLib, Lib
+  ghc-options:
+    -Wall -Wcompat
+    -F -pgmF string-syntax -optF uniform-interpolate-builder
+  build-tool-depends: string-syntax:string-syntax
+  build-depends:
+      base >=4.14 && <5
+    , string-syntax
+    , text
+  default-language: GHC2021

--- a/examples/uniform-interpolate-builder/Lib.hs
+++ b/examples/uniform-interpolate-builder/Lib.hs
@@ -1,0 +1,7 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Lib where
+import StringLib
+
+-- plain interpolate code that does not modify interpolation types
+-- or need exts etc goes here

--- a/examples/uniform-interpolate-builder/StringLib.hs
+++ b/examples/uniform-interpolate-builder/StringLib.hs
@@ -1,0 +1,69 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE UnboxedTuples #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module StringLib where
+
+-- string interpolation type code goes here
+-- often uses internals of the string, GHC.Exts etc
+
+import Data.String (IsString (fromString))
+import Data.String.Syntax.UniformInterpolateBuilder
+import Data.Text (Text)
+import Data.Text qualified as Text
+import Data.Text.Internal qualified as Text
+import Data.Text.Lazy qualified as Text.Lazy
+import Data.Text.Lazy.Builder qualified as Text (Builder)
+import Data.Text.Lazy.Builder qualified as Text.Lazy.Builder
+import Data.Text.Lazy.Builder.Int qualified as Text.Lazy.Builder
+import Data.Text.Lazy.Builder.RealFloat qualified as Text.Lazy.Builder
+import Data.Text.Array qualified as Text.Array
+import Data.Text.Internal.Builder qualified as Text.Lazy.Builder (writeN)
+import Data.String.Syntax.Internal.FixedUTF8Writer
+import GHC.Ptr (Ptr(Ptr))
+import Data.Array.Byte
+import GHC.ST (ST(ST))
+import Data.Word (Word8)
+import GHC.Base (Int (I#), mutableByteArrayContents#, plusAddr#, copyByteArrayToAddr#)
+
+
+
+{----- Text -----}
+
+instance Interpolator Text.Builder where
+  type InterpolatorBuilderFor Text.Builder = Text.Builder
+  buildInterpolator :: Text.Builder -> Text.Builder
+  buildInterpolator = id
+
+instance Interpolator Text where
+  type InterpolatorBuilderFor Text = Text.Builder
+  buildInterpolator :: Text.Builder -> Text
+  buildInterpolator = Text.Lazy.toStrict . Text.Lazy.Builder.toLazyText
+
+instance InterpolatorBuilder Text.Builder where
+  interpolateString :: String -> Text.Builder
+  interpolateString = fromString
+
+  interpolateIntegral :: (Integral a, Show a) => a -> Text.Builder
+  interpolateIntegral = Text.Lazy.Builder.decimal
+
+  interpolateRealFloat :: (RealFloat a, Show a) => a -> Text.Builder
+  interpolateRealFloat = Text.Lazy.Builder.realFloat
+
+  -- TODO: This is wrong if capacity is an overestimate
+  --       Text has an internal unexported writeAtMost that does what this should do.
+  --       .. but if the proposal went through with this, text could implement it
+  --          and people could access it via this
+  interpolateUTF8 :: FixedUTF8Writer -> Text.Builder
+  interpolateUTF8 (FixedUTF8Writer cap write) = Text.Lazy.Builder.writeN cap 
+    (\(MutableByteArray !a) (I# !off) -> () <$ write (Ptr (plusAddr# (mutableByteArrayContents# a) off)))
+
+instance Interpolate Text where
+  -- safer
+  -- interpolate = fromString . Text.unpack
+
+  -- what text should probably do (memcpy)
+  interpolate (Text.Text (ByteArray !a) (I# !offset) size@(I# !size#)) = interpolateUTF8 (FixedUTF8Writer size write) where
+    write :: Ptr Word8 -> ST s Int
+    write (Ptr !p) = ST (\s -> (# copyByteArrayToAddr# a offset p size# s, size #))

--- a/examples/uniform-interpolate-builder/main.hs
+++ b/examples/uniform-interpolate-builder/main.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+
+import Data.String.Syntax.UniformInterpolateBuilder
+import Data.Text (Text)
+
+import Lib ()
+
+main :: IO ()
+main = do
+  let name = "Alice" :: String; age = 30 :: Int; person = Person{..}
+
+  print (s"Hello ${name}! Your age is ${age}" :: String)
+  print (s"You are: ${person}" :: String)
+
+  let name2 = "Alice" :: Text
+  print (s"Hello ${name2}! Your age is ${age}" :: Text)
+
+data Person = Person { name :: String, age :: Int }
+
+instance Interpolate Person where
+  interpolate Person{..} = s"Person<${name}, ${age}>"
+  -- interpolate Person{..} = interpolateUTF8 s"Person<${name}, ${age}>"

--- a/src/Data/String/Syntax.hs
+++ b/src/Data/String/Syntax.hs
@@ -135,6 +135,15 @@ allModes =
       , processRaw = \s -> "Left " <> showT s
       , processExpr = \expr -> "Right (XX.HasClass (" <> expr <> "))"
       }
+  , InterpolationMode -- TODO: use interpolateAppend (possibly use the proposal functions throughout?)
+      { name = "uniform-interpolate-builder"
+      , autoModules = ["Data.String.Syntax.UniformInterpolateBuilder"]
+      , autoLangExts = []
+      , delimMarker = OnlyDelim "s"
+      , postProcess = \_ exprs -> "interpolateFinalize (mconcat " <> exprs <> ")"
+      , processRaw = \s -> "interpolateString " <> showT s
+      , processExpr = \expr -> "interpolateValue (" <> expr <> ")"
+      }
   ]
 
 showT :: Show a => a -> Text

--- a/src/Data/String/Syntax/Internal/FixedUTF8Writer.hs
+++ b/src/Data/String/Syntax/Internal/FixedUTF8Writer.hs
@@ -1,0 +1,94 @@
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE UnboxedTuples #-}
+
+module Data.String.Syntax.Internal.FixedUTF8Writer where
+import Data.Word (Word8)
+import Foreign.Ptr (plusPtr)
+import Control.Monad.ST (runST)
+import Data.String (IsString (fromString))
+import GHC.Encoding.UTF8 (utf8EncodePtr, utf8EncodedLength, utf8DecodeByteArray#)
+import Control.Monad.ST.Unsafe (unsafeIOToST)
+import Data.Array.Byte
+import GHC.ST (ST (ST))
+import GHC.Base (unsafeFreezeByteArray#, newPinnedByteArray#, Int (I#), mutableByteArrayContents#, resizeMutableByteArray#, Char (C#), writeCharOffAddr#, copyAddrToAddrNonOverlapping#, IO (IO), plusAddr#)
+import GHC.Ptr (Ptr(Ptr))
+import Data.Semigroup (Semigroup(stimes))
+
+-- This module or a use site will almost certainly have some sort of bug with multi-byte characters.
+-- At the very least, testing
+--  putStr $ toString (fromString "abc◕‿œœ◕dў\n")
+-- Text.putStr (interpolateFinalize (interpolateUTF8 "abc◕‿œœ◕dў\n")) -- with the example
+-- I got (with a new line after)
+--                                 abc◕‿œœ◕dў
+
+data FixedUTF8Writer
+  = FixedUTF8Writer
+   -- | Minimum buffer capacity required.
+  { capacity :: !Int
+   -- | Write to the buffer [p, p + size) and return size (where 0 <= size <= capacity)
+   --   Reading to characters this did not already write to is not permitted!
+  , write    :: forall s . Ptr Word8 -> ST s Int
+  }
+
+toMutableByteArray :: FixedUTF8Writer -> ST s (MutableByteArray s)
+toMutableByteArray (FixedUTF8Writer (I# !cap) !write) = do
+  MutableByteArray !a <- ST (\(!s) -> 
+    case newPinnedByteArray# cap s of
+      (# !s', !a #) -> (# s', MutableByteArray a #))
+  I# !size <- write (Ptr (mutableByteArrayContents# a))
+  ST (\(!s) -> 
+    case resizeMutableByteArray# a size s of
+      (# !s', !a' #) -> (# s', MutableByteArray a' #))
+
+toByteArray :: FixedUTF8Writer -> ByteArray
+toByteArray !w = runST (toMutableByteArray w >>= (\(MutableByteArray ma) -> 
+  ST (\(!s) -> 
+    case unsafeFreezeByteArray# ma s of
+      (# !s', !a #) -> (# s', ByteArray a #))))
+
+-- between this and fromString, I am not certain neither of them expect nulls or something
+-- which this interface shouldn't necessarily write (if an interpolation result wants \0,
+-- it can simply write it after its ran the write operation, using cap+1 or equivalently
+-- <> write \0)
+
+toString :: FixedUTF8Writer -> String
+toString !w = 
+  case toByteArray w of
+    ByteArray !a -> utf8DecodeByteArray# a
+
+-- | A single ASCII character. Use fromString for Unicode characters.
+ascii :: Char -> FixedUTF8Writer
+ascii (C# !c) = FixedUTF8Writer 1 (\(Ptr !p) -> ST (\s -> (# writeCharOffAddr# p 0# c s, 1 #)))
+
+instance Semigroup FixedUTF8Writer where
+  FixedUTF8Writer !cap1 !write1 <> FixedUTF8Writer !cap2 !write2
+    = FixedUTF8Writer (cap1 + cap2) write12 where
+      write12 !p = do
+        !size1 <- write1 p
+        !size2 <- write2 $! p `plusPtr` size1
+        pure $! size1 + size2
+
+  stimes !0 _ = mempty
+  stimes !1 a = a
+  stimes !i (FixedUTF8Writer !cap !write) = FixedUTF8Writer (j * cap) writeN where
+    j :: Int
+    !j = fromIntegral i
+
+    writeN :: Ptr Word8 -> ST s Int
+    writeN !p@(Ptr !a) = do
+      -- Every subsequent write should return the same size
+      !size@(I# !size#) <- write p
+      -- ... so we can just copy the already written bytes.
+      let copy !u | I# !su <- size * u 
+                  = unsafeIOToST (IO (\s -> (# copyAddrToAddrNonOverlapping# a (a `plusAddr#` su) size# s, () #)))
+      -- Starts at 1 because of previous write
+      mapM_ copy [1..j-1]
+      -- size, j times
+      return (size * j)
+
+instance Monoid FixedUTF8Writer where
+  mempty = FixedUTF8Writer 0 (\(!_) -> pure 0)
+
+instance IsString FixedUTF8Writer where
+  fromString !s | !n <- utf8EncodedLength s
+    = FixedUTF8Writer n (\(!p) -> n <$ unsafeIOToST (utf8EncodePtr p s))

--- a/src/Data/String/Syntax/UniformInterpolateBuilder.hs
+++ b/src/Data/String/Syntax/UniformInterpolateBuilder.hs
@@ -1,0 +1,118 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeFamilyDependencies #-}
+{-# LANGUAGE UndecidableSuperClasses #-}
+
+module Data.String.Syntax.UniformInterpolateBuilder (
+  module Data.String.Syntax.UniformInterpolateBuilder,
+  FixedUTF8Writer
+) where
+
+import Data.Monoid (Endo (..))
+import Data.String (IsString(..))
+import Data.Word
+import Data.String.Syntax.Internal.FixedUTF8Writer (FixedUTF8Writer)
+import qualified Data.String.Syntax.Internal.FixedUTF8Writer as Writer
+
+{----- Implementation of s"..." -----}
+
+interpolateRaw :: IsString s => String -> s
+interpolateRaw = fromString
+
+interpolateValue :: (Interpolate a, InterpolatorBuilder s) => a -> s
+interpolateValue = interpolate
+
+interpolateAppend :: Monoid s => s -> s -> s
+interpolateAppend = mappend
+
+infixr 6 `interpolateAppend` -- matches (<>)
+
+interpolateEmpty :: Monoid s => s
+interpolateEmpty = mempty
+
+interpolateFinalize :: Interpolator s => InterpolatorBuilderFor s -> s
+interpolateFinalize = buildInterpolator
+
+{----- Classes -----}
+
+class
+  ( InterpolatorBuilder (InterpolatorBuilderFor s)
+  ) => Interpolator s where
+  type InterpolatorBuilderFor s
+  buildInterpolator :: InterpolatorBuilderFor s -> s
+
+class (IsString b, Monoid b, Interpolator b) => InterpolatorBuilder b where
+  interpolateString :: String -> b
+  interpolateString = fromString
+
+  interpolateIntegral :: (Integral a, Show a) => a -> b
+  interpolateIntegral = fromString . show
+
+  interpolateRealFloat :: (RealFloat a, Show a) => a -> b
+  interpolateRealFloat = fromString . show
+
+  -- Not part of the current proposal!
+  -- TODO: Separate module containing various ... -> FixedUTF8Writer functions.
+  --       (Will be difficult to match the perf of e.g. text's implementation)
+  interpolateUTF8 :: FixedUTF8Writer -> b
+  interpolateUTF8 = fromString . Writer.toString -- should this be interpolateString? Not sure why interpolateString exists
+
+class Interpolate a where
+  {-# MINIMAL interpolate | interpolatePrec #-}
+
+  interpolate :: (InterpolatorBuilder b) => a -> b
+  interpolate = interpolatePrec 0
+
+  interpolatePrec :: (InterpolatorBuilder b) => Int -> a -> b
+  interpolatePrec _ = interpolate
+
+{----- StringBuilder -----}
+
+newtype StringBuilder = StringBuilder (Endo String)
+  deriving newtype (Semigroup, Monoid)
+instance IsString StringBuilder where
+  fromString s = StringBuilder (Endo (s <>))
+
+instance Interpolator String where
+  type InterpolatorBuilderFor String = StringBuilder
+  buildInterpolator (StringBuilder (Endo f)) = f mempty
+
+instance Interpolator StringBuilder where
+  type InterpolatorBuilderFor StringBuilder = StringBuilder
+  buildInterpolator = id
+
+instance InterpolatorBuilder StringBuilder
+
+-- Not part of the current proposal!
+instance Interpolator FixedUTF8Writer where
+  type InterpolatorBuilderFor FixedUTF8Writer = FixedUTF8Writer
+  buildInterpolator = id
+
+instance InterpolatorBuilder FixedUTF8Writer where
+  interpolateUTF8 = id
+
+{----- Interpolation of values -----}
+
+instance Interpolate String where
+  interpolate = interpolateString
+instance Interpolate Char where
+  interpolate c = interpolateString [c]
+
+instance Interpolate Int where
+  interpolate = interpolateIntegral
+instance Interpolate Word8 where
+  interpolate = interpolateIntegral
+instance Interpolate Double where
+  interpolate = interpolateRealFloat
+instance Interpolate Float where
+  interpolate = interpolateRealFloat
+instance Interpolate Bool where
+  interpolate = interpolateString . show
+
+instance Interpolate a => Interpolate (Maybe a) where
+  interpolate Nothing = interpolateString "Nothing"
+  interpolate (Just a) = interpolate a
+
+
+instance Interpolate FixedUTF8Writer where
+  interpolate = interpolateUTF8

--- a/string-syntax.cabal
+++ b/string-syntax.cabal
@@ -31,7 +31,9 @@ library
       Data.String.Syntax.ImplicitBuilder
       Data.String.Syntax.ImplicitNoBuilder
       Data.String.Syntax.ImplicitOnlyString
+      Data.String.Syntax.Internal.FixedUTF8Writer
       Data.String.Syntax.Internal.Parse
+      Data.String.Syntax.UniformInterpolateBuilder
   other-modules:
       Paths_string_syntax
   hs-source-dirs:


### PR DESCRIPTION
This adds a version that has the current version of the wired-in/unqualified class from the proposal except:
- It doesn't desugar the way the proposal desugars, since everything is currently set up to mconcat (but the proposal has append = mappend and empty = mempty anyway)
   It is probably worth changing to that or considering a new repo with it that only does qualified. You could switch between different proposed builtin versions by qualifying differently.
- I have added the custom writer I was suggesting to demonstrate
   Currently the only benefit is interpolate Text can be a memcpy for some types
   If the writer over-estimates capacity, it doesn't work for Text, which depends on an unexposed internal function (writeAtMost).
   I am not 100% sure it is correct w.r.t UTF-8, it appears to work for some specific cases I've checked (including "abc◕‿œœ◕dў\n" via String and Text).

The examples/instances are just copied across from another example.
I called it uniform in the sense that it's one interpolate class working uniformly (not the best name) as opposed to multiparam solutions
[If it's more convenient you can just take the changes and commit them yourself with whatever changes.]